### PR TITLE
Fix for 12 hour format mod 12 giving 0 hour for display; force it to 12 if 0

### DIFF
--- a/jquery.flipcountdown.js
+++ b/jquery.flipcountdown.js
@@ -133,6 +133,7 @@ jQuery.fn.flipCountDown = jQuery.fn.flipcountdown = function( _options ){
 						switch( value.constructor ){
 							case Date:
 								var h = (value.getHours()+options.tzoneOffset)%(options.am?12:24);
+								h = (options.am && h == 0) ? 12 : h;
 		
 								if( options.showHour ){
 									chars.push(parseInt(h/10));


### PR DESCRIPTION
I came across an issue when using the 12 hour format. If the hour is 12 then the mod of it from 12 is 0 and 0 is the hour displayed.